### PR TITLE
Joe/hide from agents

### DIFF
--- a/app.js
+++ b/app.js
@@ -65,6 +65,12 @@
         this.storage.totalTimeFieldId = parseInt(this.setting('total_time_field_id'), 10);
         this.storage.timeFieldId = parseInt(this.setting('time_field_id'), 10);
       }
+      if (this.setting('hide_from_agents') && this.currentUser().role() !== 'admin') {
+        this.hideFromCurrentUser = true;
+        // hide the app from non-admins
+        this.hide();
+        // change the 'review' setting
+      }
     },
 
     onAppActivated: function(app) {
@@ -95,7 +101,7 @@
     },
 
     onTicketSave: function() {
-      if (this.setting('time_submission')) {
+      if (this.setting('time_submission') && !this.hideFromCurrentUser) {
         return this.promise(function(done, fail) {
           this.saveHookPromiseDone = done;
           this.saveHookPromiseFail = fail;

--- a/manifest.json
+++ b/manifest.json
@@ -51,6 +51,11 @@
       "name": "simple_submission",
       "type": "checkbox",
       "default": false
+    },
+    {
+      "name": "hide_from_agents",
+      "type": "checkbox",
+      "default": false
     }
   ]
 }

--- a/translations/en-US.json
+++ b/translations/en-US.json
@@ -34,6 +34,10 @@
       "time_submission": {
         "label": "Edit time submission",
         "helpText": "Agents can review and edit their time before submitting the ticket."
+      },
+      "hide_from_agents": {
+        "label": "Hide the app from Agents",
+        "helpText": "The app will not be shown to Agents who do not have the 'Admin' role. This also prevents them from being able to see & edit the time upon submission."
       }
     }
   },

--- a/translations/en.json
+++ b/translations/en.json
@@ -89,6 +89,10 @@
           "value": "Prompt agents to simply enter a value in minutes before submitting the ticket",
           "title": "This is the explanation helptext of the simple submission checkbox for the admin who is installing the app"
         }
+      },
+      "hide_from_agents": {
+        "label": "Hide the app from Agents",
+        "helpText": "The app will not be shown to Agents who do not have the 'Admin' role. This also prevents them from being able to see & edit the time upon submission."
       }
     }
   },

--- a/translations/en.json
+++ b/translations/en.json
@@ -91,8 +91,14 @@
         }
       },
       "hide_from_agents": {
-        "label": "Hide the app from Agents",
-        "helpText": "The app will not be shown to Agents who do not have the 'Admin' role. This also prevents them from being able to see & edit the time upon submission."
+        "label": {
+          "value": "Hide the app from Agents",
+          "title": "this is bs"
+        },
+        "helpText": {
+          "value": "The app will not be shown to Agents who do not have the 'Admin' role. This also prevents them from being able to see & edit the time upon submission.",
+          "title": "this is bs"
+        }
       }
     }
   },

--- a/translations/en.json
+++ b/translations/en.json
@@ -93,11 +93,11 @@
       "hide_from_agents": {
         "label": {
           "value": "Hide the app from Agents",
-          "title": "this is bs"
+          "title": "This is a checkbox setting label. If the admin checks this box the app will be hidden from any agent who is not an Admin."
         },
         "helpText": {
           "value": "The app will not be shown to Agents who do not have the 'Admin' role. This also prevents them from being able to see & edit the time upon submission.",
-          "title": "this is bs"
+          "title": "This is the explanation helptext of the hide_from_agents checkbox for the admin who is installing the app."
         }
       }
     }


### PR DESCRIPTION
This adds a new setting 'hide_from_agents' (only translated to English, sorry I don't know the other languages) which will hide the app from users who are not admins using this.hide() on app.created.

To keep it completely hidden I had to add a condition to the save hook modal so that is not displayed if this setting is enabled AND the user is not an admin.