### PR TITLE
[ZD939808] Time Tracking does not show Time Spent Last Update if the value is the same as the previous update

### DIFF
--- a/app.js
+++ b/app.js
@@ -111,12 +111,13 @@
 
     onFetchAllAuditsDone: function() {
       var status = "",
+          timeDiff,
           timelogs = _.reduce(this.store('audits'), function(memo, audit) {
             var newStatus = _.find(audit.events, function(event) {
               return event.field_name == 'status';
             }, this),
             event = _.find(audit.events, function(event) {
-              return event.field_name == this.storage.timeFieldId;
+              return event.field_name == this.storage.totalTimeFieldId;
             }, this);
 
             if (newStatus){
@@ -124,8 +125,9 @@
             }
 
             if (event) {
+              timeDiff = event.value - (event.previous_value || 0);
               memo.push({
-                time: this.TimeHelper.secondsToTimeString(parseInt(event.value, 0)),
+                time: this.TimeHelper.secondsToTimeString(parseInt(timeDiff, 0)),
                 date: new Date(audit.created_at).toLocaleString(),
                 status: status,
                 localized_status: this.I18n.t(helpers.fmt('statuses.%@', status)),

--- a/app.js
+++ b/app.js
@@ -31,6 +31,7 @@
       'ticket.save'             : 'onTicketSave',
       'ticket.submit.done'      : 'onTicketSubmitDone',
       'ticket.form.id.changed'  : 'onTicketFormChanged',
+      'ticket.updated'          : 'onTicketUpdated',
       'fetchAuditsPage.done'    : 'onFetchAuditsPageDone',
       'fetchAllAudits.done'     : 'onFetchAllAuditsDone',
       'click .pause'            : 'onPauseClicked',
@@ -107,6 +108,12 @@
     onTicketSubmitDone: function() {
       this.resetElapsedTime();
       _.delay(this.getTimelogs.bind(this), 1000);
+    },
+
+    onTicketUpdated: function(updatedBy) {
+      if (updatedBy.id() !== this.currentUser().id()) {
+        this.getTimelogs();
+      }
     },
 
     onFetchAllAuditsDone: function() {


### PR DESCRIPTION
:koala: :bug: 

> If an agent submits a ticket update and the time spent on that update is the same as the previous update's time, Time Tracking will not show the new time.
This is because the `audits.json` endpoint does not show updates to fields that have not changed (such as in the audit details).

This PR uses the total time field in the audit to calculate time logs.

/cc @zendesk/quokka @benhass 

### Related
- [ZD939808](https://support.zendesk.com/agent/tickets/939808)

### Risks
- [LOW] There may be a case where times might be displayed incorrectly if the calculation fails.