### PR TITLE
Don't write to field on ticket open

### DIFF
--- a/app.js
+++ b/app.js
@@ -120,7 +120,7 @@
           timeDiff,
           isFollowUp = _.reduce(this.store('audits'), function(isFollowUp, audit) {
             return isFollowUp || (audit.via && audit.via.source && audit.via.source.rel === 'follow_up');
-          });
+          }, false);
 
       if (isFollowUp) {
         var audits = this.store('audits'),
@@ -296,10 +296,6 @@
       this.hideFields();
       this.checkForms();
 
-      if (this.currentLocation() == 'new_ticket_sidebar') {
-        this.totalTime('0');
-      }
-
       this.timeLoopID = this.setTimeLoop();
 
       this.switchTo('main', {
@@ -424,7 +420,7 @@
     },
 
     totalTime: function(time) {
-      return this.getOrSetField(this.totalTimeFieldLabel(), time);
+      return this.getOrSetField(this.totalTimeFieldLabel(), time) || 0;
     },
 
     totalTimeFieldLabel: function() {


### PR DESCRIPTION
Don't write to the ticket field if opening a ticket. It will trigger 'are you sure you want to close this ticket' if you're closing it.

Also reduce needs a second argument, I thought it would be undefined, but the spec actually makes it jump to the second loop if you don't define a second argument...

/cc @zendesk/quokka