### PR TITLE
added setting to hide app, including edit modal, from non-admin agents

### DIFF
--- a/app.js
+++ b/app.js
@@ -62,8 +62,6 @@
         this.storage.timeFieldId = parseInt(this.setting('time_field_id'), 10);
       }
       if (this.setting('hide_from_agents') && this.currentUser().role() !== 'admin') {
-        // hide the app from non-admins
-        this.hideFromCurrentUser = true;
         this.hide();
       }
     },
@@ -95,7 +93,7 @@
     },
 
     onTicketSave: function() {
-      if (this.setting('time_submission') && !this.hideFromCurrentUser) {
+      if (this.setting('time_submission') && this.visible()) {
         return this.promise(function(done, fail) {
           this.saveHookPromiseDone = done;
           this.saveHookPromiseFail = fail;

--- a/app.js
+++ b/app.js
@@ -61,6 +61,11 @@
         this.storage.totalTimeFieldId = parseInt(this.setting('total_time_field_id'), 10);
         this.storage.timeFieldId = parseInt(this.setting('time_field_id'), 10);
       }
+      if (this.setting('hide_from_agents') && this.currentUser().role() !== 'admin') {
+        // hide the app from non-admins
+        this.hideFromCurrentUser = true;
+        this.hide();
+      }
     },
 
     onAppActivated: function(app) {
@@ -90,7 +95,7 @@
     },
 
     onTicketSave: function() {
-      if (this.setting('time_submission')) {
+      if (this.setting('time_submission') && !this.hideFromCurrentUser) {
         return this.promise(function(done, fail) {
           this.saveHookPromiseDone = done;
           this.saveHookPromiseFail = fail;

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
     "ticket_sidebar"
   ],
   "frameworkVersion": "1.0",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "parameters": [
     {
       "name": "time_field_id",

--- a/manifest.json
+++ b/manifest.json
@@ -29,6 +29,11 @@
       "default": true
     },
     {
+      "name": "hide_from_agents",
+      "type": "checkbox",
+      "default": false
+    },
+    {
       "name": "auto_pause_resume",
       "type": "checkbox",
       "default": true


### PR DESCRIPTION
added new setting that will enable admins to hide the app from non-admin agents for super-sneaky time tracking :ghost: 

the setting and user role are evaluated on `app.created`
if setting enabled and user not an admin -> app is hidden and variable set

added condition for that variable to if statement for showing the edit modal on submit (so Admins can still have the option to edit their own submission with this setting enabled)



