### PR TITLE
[ZD1216969][OFFAPPS][BUG] Time fields showing incorrectly

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,7 +30,7 @@
       'app.willDestroy'         : 'onAppWillDestroy',
       'ticket.save'             : 'onTicketSave',
       'ticket.submit.done'      : 'onTicketSubmitDone',
-      'ticket.form.id.changed'  : 'onTicketFormChanged',
+      '*.changed'               : 'onAnyTicketFieldChanged',
       'ticket.updated'          : 'onTicketUpdated',
       'fetchAuditsPage.done'    : 'onFetchAuditsPageDone',
       'fetchAllAudits.done'     : 'onFetchAllAuditsDone',
@@ -88,7 +88,7 @@
       }
     },
 
-    onTicketFormChanged: function() {
+    onAnyTicketFieldChanged: function() {
       _.defer(this.hideFields.bind(this));
     },
 
@@ -349,7 +349,7 @@
       _.each([this.timeFieldLabel(), this.totalTimeFieldLabel()], function(f) {
         var field = this.ticketFields(f);
 
-        if (field) {
+        if (field && field.isVisible()) {
           field.hide();
         }
       }, this);


### PR DESCRIPTION
:koala:

Fixes an issue where the Time spent and Total time custom fields created by the app are incorrectly shown after the Ticket Form changes, or, when the Conditional Fields App is also present and modifying the visibility of Ticket Fields.

/cc @zendesk/vegemite 

### References
 - Ticket link: https://support.zendesk.com/agent/tickets/1216969

### Risks
 - [LOW] There may be an impact on performance in relation to the rendering of Ticket Fields since the Time Fields will always be hidden, if showing.  This scenario is unlikely, since the guard should prevent unnecessary setting and the Time fields are only infrequently being incorrectly shown.