### PR TITLE
Guard status if it's not found

### DIFF
--- a/app.js
+++ b/app.js
@@ -174,6 +174,7 @@
                 time: this.TimeHelper.secondsToTimeString(parseInt(timeDiff, 10)),
                 date: new Date(audit.created_at).toLocaleString(),
                 status: status,
+                // Guard around i18n status because some old apps don't have this
                 localized_status: status ? this.I18n.t(helpers.fmt('statuses.%@', status)) : "",
                 user: _.find(this.store('users'), function(user) {
                   return user.id === audit.author_id;

--- a/app.js
+++ b/app.js
@@ -174,7 +174,7 @@
                 time: this.TimeHelper.secondsToTimeString(parseInt(timeDiff, 10)),
                 date: new Date(audit.created_at).toLocaleString(),
                 status: status,
-                localized_status: this.I18n.t(helpers.fmt('statuses.%@', status)),
+                localized_status: status ? this.I18n.t(helpers.fmt('statuses.%@', status)) : "",
                 user: _.find(this.store('users'), function(user) {
                   return user.id === audit.author_id;
                 })


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description

Guard status if it's not found. Some old tickets (or at least one on our acceptance env) are missing the status field from the audit. This ensures the app doesn't blow up it encounters one of these tickets.

### References
* JIRA: 

### Risks
* low: bug fix/guard