### PR TITLE
OFFAPPS-756 localise the setup link

### DIFF
--- a/app.js
+++ b/app.js
@@ -292,7 +292,7 @@
 
           if (!valid) {
             var localeString = this.currentUser().locale().toLowerCase();
-            if (localeString === 'pt') {
+            if (localeString.indexOf('pt') === 0) {
               localeString = 'pt-br';
             } else if (localeString.indexOf('en') === 0) {
               localeString = 'en-us';

--- a/app.js
+++ b/app.js
@@ -296,6 +296,10 @@
               localeString = 'pt-br';
             } else if (localeString.indexOf('en') === 0) {
               localeString = 'en-us';
+            } else if (localeString.indexOf('es') == 0) {
+              localeString = 'es';
+            } else if (localeString.indexOf('fr') === 0) {
+              localeString = 'fr';
             }
             var link = this.SETUP_INFO.fmt(localeString);
             this.switchTo('setup_info', { link: link });

--- a/app.js
+++ b/app.js
@@ -291,8 +291,7 @@
           });
 
           if (!valid) {
-            var localeString = this.generateLocaleForHC();
-            var link = helpers.fmt(this.SETUP_INFO, localeString);
+            var link = helpers.fmt(this.SETUP_INFO, this.localeForHC());
             this.switchTo('setup_info', { link: link });
             this.$('.expand-bar').remove();
             this.onAppWillDestroy();
@@ -460,7 +459,7 @@
       return parseInt((this.ticket().customField(fieldLabel) || 0), 10);
     },
 
-    generateLocaleForHC: function() {
+    localeForHC: function() {
       var localeString = this.currentUser().locale().toLowerCase();
       if (localeString.indexOf('pt') === 0) {
         localeString = 'pt-br';

--- a/app.js
+++ b/app.js
@@ -13,7 +13,7 @@
   }
 
   return {
-    SETUP_INFO: 'https://support.zendesk.com/entries/69791168-Setting-up-the-Time-Tracking-app',
+    SETUP_INFO: 'https://support.zendesk.com/hc/%@/articles/203662506',
 
     storage: {},
 
@@ -291,7 +291,14 @@
           });
 
           if (!valid) {
-            this.switchTo('setup_info', { link: this.SETUP_INFO });
+            var localeString = this.currentUser().locale().toLowerCase();
+            if (localeString === 'pt') {
+              localeString = 'pt-br';
+            } else if (localeString.indexOf('en') === 0) {
+              localeString = 'en-us';
+            }
+            var link = this.SETUP_INFO.fmt(localeString);
+            this.switchTo('setup_info', { link: link });
             this.$('.expand-bar').remove();
             this.onAppWillDestroy();
           }

--- a/app.js
+++ b/app.js
@@ -291,17 +291,8 @@
           });
 
           if (!valid) {
-            var localeString = this.currentUser().locale().toLowerCase();
-            if (localeString.indexOf('pt') === 0) {
-              localeString = 'pt-br';
-            } else if (localeString.indexOf('en') === 0) {
-              localeString = 'en-us';
-            } else if (localeString.indexOf('es') == 0) {
-              localeString = 'es';
-            } else if (localeString.indexOf('fr') === 0) {
-              localeString = 'fr';
-            }
-            var link = this.SETUP_INFO.fmt(localeString);
+            var localeString = this.generateLocaleForHC();
+            var link = helpers.fmt(this.SETUP_INFO, localeString);
             this.switchTo('setup_info', { link: link });
             this.$('.expand-bar').remove();
             this.onAppWillDestroy();
@@ -467,6 +458,20 @@
       }
 
       return parseInt((this.ticket().customField(fieldLabel) || 0), 10);
+    },
+
+    generateLocaleForHC: function() {
+      var localeString = this.currentUser().locale().toLowerCase();
+      if (localeString.indexOf('pt') === 0) {
+        localeString = 'pt-br';
+      } else if (localeString.indexOf('en') === 0) {
+        localeString = 'en-us';
+      } else if (localeString.indexOf('es') == 0) {
+        localeString = 'es';
+      } else if (localeString.indexOf('fr') === 0) {
+        localeString = 'fr';
+      }
+      return localeString;
     },
 
     TimeHelper: {


### PR DESCRIPTION
https://zendesk.atlassian.net/browse/OFFAPPS-756

This falls back to whatever language you last chose in the HC dropdown, unlike the `/entries` URL - not sure how that works but in my testing it seemed to either go to English or a 404 page.

@zendesk/vegemite 

### Risks
- users are taken to a non-working page or a wrong-language page when clicking the setup link within the timetracking app