### PR TITLE
dont block saving tickets when the app is not setup properly

### DIFF
--- a/app.js
+++ b/app.js
@@ -103,7 +103,7 @@
     },
 
     onTicketSave: function() {
-      if (this.setting('time_submission') && this.visible()) {
+      if (this.setting('time_submission') && this.visible() && !this.invalid) {
         return this.promise(function(done, fail) {
           this.saveHookPromiseDone = done;
           this.saveHookPromiseFail = fail;
@@ -291,6 +291,7 @@
           });
 
           if (!valid) {
+            this.invalid = true;
             var link = helpers.fmt(this.SETUP_INFO, this.localeForHC());
             this.switchTo('setup_info', { link: link });
             this.$('.expand-bar').remove();


### PR DESCRIPTION
In [some cases](https://appsqa-patagonia.zd-staging.com/agent/tickets/49) an incorrectly setup app will try to show a modal, however since it has switched to the `setup_info` template, there is no `.modal` div, so it doesn't show anything and just blocks the ticket from saving.

cc @zendesk/vegemite 

#### Risks

- [low] timetracking app stops logging time in some weird config
- [low] timetracking app blocks tickets from saving in some weird config