### PR TITLE
try the new css compiler experiment

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,6 +12,7 @@
     "new_ticket_sidebar",
     "ticket_sidebar"
   ],
+  "experiments": {"newCssCompiler": true},
   "frameworkVersion": "1.0",
   "version": "0.4.6",
   "parameters": [


### PR DESCRIPTION
### Description

This app has more css than most of the official ones. We should start rolling out the `newCssCompiler` experiment, which compiles the sass code to css using a different compiler.

cc @zendesk/vegemite 

### Risks

- [medium] some part of the app does not look right