### PR TITLE
[TTA-1] Different mechanism for counting time

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,7 +40,7 @@
     events: {
       'app.created'             : 'onAppCreated',
       'app.activated'           : 'onAppActivated',
-      'app.deactivated'         : 'onAppFocusOut',
+      'app.deactivated'         : 'onAppDeactivated',
       'app.willDestroy'         : 'onAppWillDestroy',
       'ticket.save'             : 'onTicketSave',
       'ticket.submit.done'      : 'onTicketSubmitDone',
@@ -90,7 +90,7 @@
       clearInterval(this.timeLoopID);
     },
 
-    onAppFocusOut: function() {
+    onAppDeactivated: function() {
       if (this.setting('auto_pause_resume')) {
         this.autoPause();
       }

--- a/app.js
+++ b/app.js
@@ -313,7 +313,7 @@
           this.saveHookPromiseIsDone = false;
           this.saveHookPromiseIsDoneDebug = true;
         } else {
-          this.commitTicketTime();
+          this.commitTicketTime(timeAttempt);
 
           // flag here that saveHookPromiseDone is called after hiding the modal
           this.saveHookPromiseIsDone = true;

--- a/app.js
+++ b/app.js
@@ -479,7 +479,7 @@
      */
 
     elapsedTime: function(time) {
-      if (typeof time !== "undefined") {
+      if (time !== undefined) {
         this.realElapsedTime = time * 1000;
       }
       return (this.realElapsedTime / 1000) | 0; // bitwise or for rounding
@@ -582,7 +582,7 @@
     time: function(time) {
       var fieldLabel = helpers.fmt('custom_field_%@', timeFieldId);
 
-      if (typeof time !== 'undefined') {
+      if (time !== undefined) {
         return this.ticket().customField(fieldLabel, time);
       } else {
         return parseInt(this.ticket().customField(fieldLabel) || 0, 10);
@@ -590,10 +590,10 @@
     },
 
     totalTime: function(time) {
-      if (this.currentLocation() === 'new_ticket_sidebar' && typeof time === 'undefined') return 0;
+      if (this.currentLocation() === 'new_ticket_sidebar' && time === undefined) return 0;
       var fieldLabel = helpers.fmt('custom_field_%@', totalTimeFieldId);
 
-      if (typeof time !== 'undefined') {
+      if (time !== undefined) {
         return this.ticket().customField(fieldLabel, time);
       } else {
         return parseInt(this.ticket().customField(fieldLabel) || 0, 10);

--- a/app.js
+++ b/app.js
@@ -552,8 +552,10 @@
       var ticketTime = getTick() - this.startTime;
 
       this.resume(); // Make sure to unpause to calculate paused timer.
+
       if (ticketTime < this.elapsedPausedTime) {
-        throw new Error(helpers.fmt('We paused more than we spent time on the ticket? Impossible! ticketTime: "%@",pausedTime: "%@"', ticketTime, this.elapsedPausedTime));
+        console.error(helpers.fmt('We paused more than we spent time on the ticket? Impossible! ticketTime: "%@",pausedTime: "%@"', ticketTime, this.elapsedPausedTime));
+        return 0;
       }
 
       return Math.floor((ticketTime - this.elapsedPausedTime) / 1000);

--- a/app.js
+++ b/app.js
@@ -66,7 +66,7 @@
      *
      */
     onAppCreated: function() {
-      if (timeFieldId && totalTimeFieldId) {
+      if (!timeFieldId || !totalTimeFieldId) {
         if (this.installationId() > 0) {
           var totalTimeField = this.requirement('total_time_field'),
               timeLastUpdateField = this.requirement('time_last_update_field');
@@ -74,14 +74,13 @@
           totalTimeFieldId = totalTimeField && totalTimeField.requirement_id;
           timeFieldId = timeLastUpdateField && timeLastUpdateField.requirement_id;
 
-          this.initialize();
-
         } else {
-          _.defer(this.initialize.bind(this));
           totalTimeFieldId = parseInt(this.setting('total_time_field_id'), 10);
           timeFieldId = parseInt(this.setting('time_field_id'), 10);
         }
       }
+
+      this.initialize();
 
       if (this.setting('hide_from_agents') && this.currentUser().role() !== 'admin') {
         this.hide();

--- a/app.js
+++ b/app.js
@@ -22,8 +22,6 @@
     // update.
     MAX_TIME: 1209600, // 1209600 = two weeks in seconds
 
-    storage: {},
-
     requests: {
       fetchAuditsPage: function(url) {
         return {
@@ -483,7 +481,7 @@
       if (time !== undefined) {
         this.realElapsedTime = time * 1000;
       }
-      return (this.realElapsedTime / 1000) | 0; // bitwise or for rounding
+      return Math.floor(this.realElapsedTime / 1000);
     },
 
     setTimeLoop: function() {
@@ -558,11 +556,11 @@
         throw new Error(helpers.fmt('We paused more than we spent time on the ticket? Impossible! ticketTime: "%@",pausedTime: "%@"', ticketTime, this.elapsedPausedTime));
       }
 
-      return (ticketTime - this.elapsedPausedTime) / 1000 | 0;
+      return Math.floor((ticketTime - this.elapsedPausedTime) / 1000);
     },
 
-    commitTicketTime: function() {
-      var ticketTime = this.ticketTime();
+    commitTicketTime: function(ticketTime) {
+      ticketTime = ticketTime || this.ticketTime();
 
       this.time(ticketTime);
       this.totalTime(this.totalTime() + ticketTime);

--- a/app.js
+++ b/app.js
@@ -87,7 +87,7 @@
     },
 
     onAppWillDestroy: function() {
-      clearInterval(this.timeLoopID);
+      this.clearTimeLoop();
     },
 
     onAppDeactivated: function() {
@@ -409,7 +409,7 @@
       this.hideFields();
       this.checkForms();
 
-      this.timeLoopID = this.setTimeLoop();
+      this.setTimeLoop();
 
       this.switchTo('main', {
         manualPauseResume: this.setting('manual_pause_resume'),
@@ -480,7 +480,9 @@
       this.lastTick = getTick();
       this.elapsedTime(0);
 
-      return setInterval(function() {
+      if (this.timeLoopID) { throw new Error('There is already a timeloop running for this instance.'); }
+
+      this.timeLoopID = setInterval(function() {
         var now = getTick();
         if (!this.paused) {
           this.realElapsedTime += now - this.lastTick;
@@ -489,6 +491,11 @@
         }
         this.lastTick = now;
       }.bind(this), 1000);
+    },
+
+    clearTimeLoop: function() {
+      clearInterval(this.timeLoopID);
+      this.timeLoopID = undefined;
     },
 
     updateTime: function(time) {

--- a/app.js
+++ b/app.js
@@ -2,6 +2,8 @@
 (function() {
   'use_strict';
 
+  var totalTimeFieldId, timeFieldId;
+
   function getTick() {
     // for newer browsers rely on performance.now()
     if (typeof performance !== 'undefined' && performance.now) {
@@ -66,14 +68,15 @@
       if (this.installationId()) {
         var totalTimeField = this.requirement('total_time_field'),
             timeLastUpdateField = this.requirement('time_last_update_field');
-        this.storage.totalTimeFieldId = totalTimeField && totalTimeField.requirement_id;
-        this.storage.timeFieldId = timeLastUpdateField && timeLastUpdateField.requirement_id;
+
+        totalTimeFieldId = totalTimeField && totalTimeField.requirement_id;
+        timeFieldId = timeLastUpdateField && timeLastUpdateField.requirement_id;
 
         this.initialize();
       } else {
         _.defer(this.initialize.bind(this));
-        this.storage.totalTimeFieldId = parseInt(this.setting('total_time_field_id'), 10);
-        this.storage.timeFieldId = parseInt(this.setting('time_field_id'), 10);
+        totalTimeFieldId = parseInt(this.setting('total_time_field_id'), 10);
+        timeFieldId = parseInt(this.setting('time_field_id'), 10);
       }
       if (this.setting('hide_from_agents') && this.currentUser().role() !== 'admin') {
         this.hide();
@@ -196,7 +199,7 @@
         if (newAudits.length) {
 
           var isThisEvent = function(event) {
-            return event.field_name == this.storage.totalTimeFieldId;
+            return event.field_name == totalTimeFieldId;
           };
 
           for (var i = 0; i < newAudits.length; i++) {
@@ -222,7 +225,7 @@
             return event.field_name == 'status';
           }, this),
           auditEvent = _.find(audit.events, function(event) {
-            return event.field_name == this.storage.totalTimeFieldId;
+            return event.field_name == totalTimeFieldId;
           }, this);
 
           if (newStatus) {
@@ -375,8 +378,8 @@
           fetch.call(this, data.next_page);
         } else {
           var requiredTicketFieldIds = [
-                this.storage.timeFieldId,
-                this.storage.totalTimeFieldId
+                timeFieldId,
+                totalTimeFieldId
               ];
 
           forms = _.filter(forms, function(form) {
@@ -545,11 +548,11 @@
     },
 
     totalTimeFieldLabel: function() {
-      return this.buildFieldLabel(this.storage.totalTimeFieldId);
+      return this.buildFieldLabel(totalTimeFieldId);
     },
 
     timeFieldLabel: function() {
-      return this.buildFieldLabel(this.storage.timeFieldId);
+      return this.buildFieldLabel(timeFieldId);
     },
 
     buildFieldLabel: function(id) {

--- a/app.js
+++ b/app.js
@@ -459,8 +459,8 @@
     },
 
     hideFields: function() {
-      _.each([this.timeFieldLabel(), this.totalTimeFieldLabel()], function(f) {
-        var field = this.ticketFields(f);
+      _.each([ timeFieldId, totalTimeFieldId ], function(fieldId) {
+        var field = this.ticketFields(helpers.fmt('custom_field_%@', fieldId));
 
         if (field && field.isVisible()) {
           field.hide();
@@ -539,32 +539,24 @@
     },
 
     time: function(time) {
-      return this.getOrSetField(this.timeFieldLabel(), time);
+      var fieldLabel = helpers.fmt('custom_field_%@', timeFieldId);
+
+      if (typeof time !== 'undefined') {
+        return this.ticket().customField(fieldLabel, time);
+      } else {
+        return parseInt(this.ticket().customField(fieldLabel) || 0, 10);
+      }
     },
 
     totalTime: function(time) {
       if (this.currentLocation() === 'new_ticket_sidebar' && typeof time === 'undefined') return 0;
-      return this.getOrSetField(this.totalTimeFieldLabel(), time) || 0;
-    },
+      var fieldLabel = helpers.fmt('custom_field_%@', totalTimeFieldId);
 
-    totalTimeFieldLabel: function() {
-      return this.buildFieldLabel(totalTimeFieldId);
-    },
-
-    timeFieldLabel: function() {
-      return this.buildFieldLabel(timeFieldId);
-    },
-
-    buildFieldLabel: function(id) {
-      return helpers.fmt('custom_field_%@', id);
-    },
-
-    getOrSetField: function(fieldLabel, value) {
-      if (typeof value !== "undefined") {
-        return this.ticket().customField(fieldLabel, value);
+      if (typeof time !== 'undefined') {
+        return this.ticket().customField(fieldLabel, time);
+      } else {
+        return parseInt(this.ticket().customField(fieldLabel) || 0, 10);
       }
-
-      return parseInt((this.ticket().customField(fieldLabel) || 0), 10);
     },
 
     localeForHC: function() {


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
To counter (pun intended) the counting problem Roman and I have doctored up a new mechanism for keeping track of time.

Instead of using setTimeInterval to count we use events.

1 - We set a `startTime` the moment a ticket is opened. We **never** write to `startTime` again, unless ticket is saved, when we reset the timers.
2 - We get the time the moment we save a ticket and we subtract the `startTime`. Now we have a total ticket time an agent had that ticket open in their browser. Paused or unpaused, active or inactive, we have a total time an agent cannot exceed.
3 - We keep track of an agent pausing and unpausing (or active/inactive) and keep track of the paused time. But not with an interval, instead with events. We accumulate total paused time (or `realElapsedTimePaused`).
4 - When we save, we get total ticket time - paused time. We check that paused time is not bigger than ticket time because that would definitely be a bug.
5 - We save the new time to the 2 ticket fields.

Note that all the previous code for counting is still in the code and used to update the UI. However the time used to update the ticket fields is now completely independent.

In the future, if this approach seems to solve the issue, we can clean up the code and remove the old timer code.

### References
* JIRA: https://zendesk.atlassian.net/browse/TTA-1

### Risks
- [medium] Time tracking field count is still incorrect.