### PR TITLE
TTA-8 Option to resume timer when any field changes

### DIFF
--- a/app.js
+++ b/app.js
@@ -112,6 +112,9 @@
     onAnyTicketFieldChanged: function() {
       _.defer(this.hideFields.bind(this));
       if (this.setting('resume_on_changes') && this.manuallyPaused) {
+        this.$('.play i').addClass('active');
+        this.$('.pause i').removeClass('active');
+        
         this.resume();
       }
     },

--- a/app.js
+++ b/app.js
@@ -54,12 +54,12 @@
       'click .pause'            : 'onPauseClicked',
       'click .play'             : 'onPlayClicked',
       'click .reset'            : 'onResetClicked',
-      'click #time-modal-save'  : 'onTimeModalSaveClicked',
-      'shown #time-modal'       : 'onTimeModalShown',
-      'hidden #time-modal'      : 'onTimeModalHidden',
-      'shown #resume-modal'     : 'onResumeModalShown',
-      'click #resume-modal-yes' : 'onResumeModalYesClicked',
-      'click #resume-modal-no'  : 'onResumeModalNoClicked',
+      'click .time-modal-save'  : 'onTimeModalSaveClicked',
+      'shown .time-modal'       : 'onTimeModalShown',
+      'hidden .time-modal'      : 'onTimeModalHidden',
+      'shown .resume-modal'     : 'onResumeModalShown',
+      'click .resume-modal-yes' : 'onResumeModalYesClicked',
+      'click .resume-modal-no'  : 'onResumeModalNoClicked',
       'click .expand-bar'       : 'onTimelogsClicked'
     },
 
@@ -115,7 +115,7 @@
     onAnyTicketFieldChanged: function() {
       _.defer(this.hideFields.bind(this));
       if (this.setting('resume_on_changes') && this.manuallyPaused && !this.refusedResume) {
-        this.$('#resume-modal').modal('show');
+        this.$('.resume-modal').modal('show');
       }
     },
 
@@ -329,7 +329,7 @@
           this.saveHookPromiseDone();
         }
 
-        this.$('#time-modal').modal('hide');
+        this.$('.time-modal').modal('hide');
 
       } catch (e) {
         if (e.message == 'bad_time_format') {
@@ -343,7 +343,7 @@
     onTimeModalShown: function() {
       var timeout = 15,
           $timeout = this.$('span.modal-timer'),
-          $modal = this.$('#time-modal');
+          $modal = this.$('.time-modal');
 
       this.modalTimeoutID = setInterval(function() {
         timeout -= 1;
@@ -355,7 +355,7 @@
         }
       }.bind(this), 1000);
 
-      $modal.find('#time-modal-save').focus();
+      $modal.find('.time-modal-save').focus();
     },
 
     onTimeModalHidden: function() {
@@ -374,18 +374,18 @@
     },
 
     onResumeModalShown: function() {
-      this.$('#resume-modal').find('#resume-modal-yes').focus();
+      this.$('.resume-modal').find('.resume-modal-yes').focus();
     },
 
     onResumeModalYesClicked: function() {
       this.$('.play').click();
 
-      this.$('#resume-modal').modal('hide');
+      this.$('.resume-modal').modal('hide');
     },
 
     onResumeModalNoClicked: function() {
       this.refusedResume = true;
-      this.$('#resume-modal').modal('hide');
+      this.$('.resume-modal').modal('hide');
     },
 
     /*
@@ -538,7 +538,7 @@
       } else {
         this.$('.modal-time').val(TimeHelpers.secondsToTimeString(this.elapsedTime()));
       }
-      this.$('#time-modal').modal('show');
+      this.$('.time-modal').modal('show');
     },
 
     resetElapsedTime: function() {

--- a/app.js
+++ b/app.js
@@ -58,6 +58,7 @@
       'shown .modal'            : 'onModalShown',
       'hidden .modal'           : 'onModalHidden',
       'click .resume-modal-yes' : 'onResumeModalYesClicked',
+      'click .resume-modal-no'  : 'onResumeModalNoClicked',
       'click .expand-bar'       : 'onTimelogsClicked'
     },
 
@@ -112,7 +113,7 @@
 
     onAnyTicketFieldChanged: function() {
       _.defer(this.hideFields.bind(this));
-      if (this.setting('resume_on_changes') && this.manuallyPaused) {
+      if (this.setting('resume_on_changes') && this.manuallyPaused && !this.refusedResume) {
         this.$('#resume-modal').modal('show');
       }
     },
@@ -272,6 +273,7 @@
       $el.find('i').addClass('active');
       this.$('.play i').removeClass('active');
 
+      this.refusedResume = false;
       this.manuallyPaused = true;
       this.pause();
     },
@@ -377,6 +379,11 @@
       this.manuallyPaused = false;
       this.resume();
 
+      this.$('#resume-modal').modal('hide');
+    },
+
+    onResumeModalNoClicked: function() {
+      this.refusedResume = true;
       this.$('#resume-modal').modal('hide');
     },
 

--- a/app.js
+++ b/app.js
@@ -54,12 +54,12 @@
       'click .pause'            : 'onPauseClicked',
       'click .play'             : 'onPlayClicked',
       'click .reset'            : 'onResetClicked',
-      'click .time-modal-save'  : 'onTimeModalSaveClicked',
+      'click #time-modal-save'  : 'onTimeModalSaveClicked',
       'shown #time-modal'       : 'onTimeModalShown',
       'hidden #time-modal'      : 'onTimeModalHidden',
       'shown #resume-modal'     : 'onResumeModalShown',
-      'click .resume-modal-yes' : 'onResumeModalYesClicked',
-      'click .resume-modal-no'  : 'onResumeModalNoClicked',
+      'click #resume-modal-yes' : 'onResumeModalYesClicked',
+      'click #resume-modal-no'  : 'onResumeModalNoClicked',
       'click .expand-bar'       : 'onTimelogsClicked'
     },
 
@@ -355,7 +355,7 @@
         }
       }.bind(this), 1000);
 
-      $modal.find('.time-modal-save').focus();
+      $modal.find('#time-modal-save').focus();
     },
 
     onTimeModalHidden: function() {
@@ -374,7 +374,7 @@
     },
 
     onResumeModalShown: function() {
-      this.$('#resume-modal').find('.resume-modal-yes').focus();
+      this.$('#resume-modal').find('#resume-modal-yes').focus();
     },
 
     onResumeModalYesClicked: function() {

--- a/app.js
+++ b/app.js
@@ -57,6 +57,7 @@
       'click .modal-save'       : 'onModalSaveClicked',
       'shown .modal'            : 'onModalShown',
       'hidden .modal'           : 'onModalHidden',
+      'click .resume-modal-yes' : 'onResumeModalYesClicked',
       'click .expand-bar'       : 'onTimelogsClicked'
     },
 
@@ -112,10 +113,7 @@
     onAnyTicketFieldChanged: function() {
       _.defer(this.hideFields.bind(this));
       if (this.setting('resume_on_changes') && this.manuallyPaused) {
-        this.$('.play i').addClass('active');
-        this.$('.pause i').removeClass('active');
-        
-        this.resume();
+        this.$('#resume-modal').modal('show');
       }
     },
 
@@ -370,6 +368,16 @@
           this.saveHookPromiseFail(this.I18n.t('errors.save_hook'));
         }
       }
+    },
+
+    onResumeModalYesClicked: function() {
+      this.$('.play i').addClass('active');
+      this.$('.pause i').removeClass('active');
+
+      this.manuallyPaused = false;
+      this.resume();
+
+      this.$('#resume-modal').modal('hide');
     },
 
     /*

--- a/app.js
+++ b/app.js
@@ -54,9 +54,9 @@
       'click .pause'            : 'onPauseClicked',
       'click .play'             : 'onPlayClicked',
       'click .reset'            : 'onResetClicked',
-      'click .modal-save'       : 'onModalSaveClicked',
-      'shown .modal'            : 'onModalShown',
-      'hidden .modal'           : 'onModalHidden',
+      'click .time-modal-save'  : 'onTimeModalSaveClicked',
+      'shown #time-modal'       : 'onTimeModalShown',
+      'hidden #time-modal'      : 'onTimeModalHidden',
       'click .resume-modal-yes' : 'onResumeModalYesClicked',
       'click .resume-modal-no'  : 'onResumeModalNoClicked',
       'click .expand-bar'       : 'onTimelogsClicked'
@@ -297,7 +297,7 @@
       this.$('.expand-bar').toggleClass('expanded');
     },
 
-    onModalSaveClicked: function() {
+    onTimeModalSaveClicked: function() {
       var timeString = this.$('.modal-time').val();
 
       try {
@@ -312,7 +312,7 @@
           // submitting large values due to a possible bug
           //
           // Problem ticket: https://support.zendesk.com/agent/tickets/1637774
-          this.maxValueExceededDebugLogs('onModalSaveClicked', timeAttempt);
+          this.maxValueExceededDebugLogs('onTimeModalSaveClicked', timeAttempt);
 
           // Fail updating the ticket by passing a false value to the modal
           // hide function
@@ -328,7 +328,7 @@
           this.saveHookPromiseDone();
         }
 
-        this.$('.modal').modal('hide');
+        this.$('#time-modal').modal('hide');
 
       } catch (e) {
         if (e.message == 'bad_time_format') {
@@ -339,10 +339,10 @@
       }
     },
 
-    onModalShown: function() {
+    onTimeModalShown: function() {
       var timeout = 15,
           $timeout = this.$('span.modal-timer'),
-          $modal = this.$('.modal');
+          $modal = this.$('#time-modal');
 
       this.modalTimeoutID = setInterval(function() {
         timeout -= 1;
@@ -354,10 +354,10 @@
         }
       }.bind(this), 1000);
 
-      $modal.find('.modal-save').focus();
+      $modal.find('.time-modal-save').focus();
     },
 
-    onModalHidden: function() {
+    onTimeModalHidden: function() {
       clearInterval(this.modalTimeoutID);
 
       if (!this.saveHookPromiseIsDone) {
@@ -537,7 +537,7 @@
       } else {
         this.$('.modal-time').val(TimeHelpers.secondsToTimeString(this.elapsedTime()));
       }
-      this.$('.modal').modal('show');
+      this.$('#time-modal').modal('show');
     },
 
     resetElapsedTime: function() {

--- a/app.js
+++ b/app.js
@@ -378,11 +378,7 @@
     },
 
     onResumeModalYesClicked: function() {
-      this.$('.play i').addClass('active');
-      this.$('.pause i').removeClass('active');
-
-      this.manuallyPaused = false;
-      this.resume();
+      this.$('.play').click();
 
       this.$('#resume-modal').modal('hide');
     },

--- a/app.js
+++ b/app.js
@@ -111,6 +111,9 @@
 
     onAnyTicketFieldChanged: function() {
       _.defer(this.hideFields.bind(this));
+      if (this.setting('resume_on_changes') && this.manuallyPaused) {
+        this.resume();
+      }
     },
 
     maxValueExceededDebugLogs: function(fname, timeAttempt) {

--- a/app.js
+++ b/app.js
@@ -57,6 +57,7 @@
       'click .time-modal-save'  : 'onTimeModalSaveClicked',
       'shown #time-modal'       : 'onTimeModalShown',
       'hidden #time-modal'      : 'onTimeModalHidden',
+      'shown #resume-modal'     : 'onResumeModalShown',
       'click .resume-modal-yes' : 'onResumeModalYesClicked',
       'click .resume-modal-no'  : 'onResumeModalNoClicked',
       'click .expand-bar'       : 'onTimelogsClicked'
@@ -370,6 +371,10 @@
           this.saveHookPromiseFail(this.I18n.t('errors.save_hook'));
         }
       }
+    },
+
+    onResumeModalShown: function() {
+      this.$('#resume-modal').find('.resume-modal-yes').focus();
     },
 
     onResumeModalYesClicked: function() {

--- a/manifest.json
+++ b/manifest.json
@@ -52,6 +52,11 @@
       "default": true
     },
     {
+      "name": "resume_on_changes",
+      "type": "checkbox",
+      "default": false
+    },
+    {
       "name": "time_submission",
       "type": "checkbox",
       "default": true

--- a/templates/main.hdbs
+++ b/templates/main.hdbs
@@ -56,7 +56,7 @@
     <p>{{t "views.resume_modal.body"}}</p>
   </div>
   <div class="modal-footer">
-    <button class="btn" aria-hidden="true" data-dismiss="modal">{{t "views.resume_modal.no"}}</button>
+    <button class="btn resume-modal-no">{{t "views.resume_modal.no"}}</button>
     <button class="btn btn-primary resume-modal-yes">{{t "views.resume_modal.yes"}}</button>
   </div>
 </div>

--- a/templates/main.hdbs
+++ b/templates/main.hdbs
@@ -46,3 +46,17 @@
     <button class="btn btn-primary modal-save">{{t "views.modal.save"}}</button>
   </div>
 </div>
+
+<div class="modal hide fade" id="resume-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+  <div class="modal-header">
+    <button type="button" class="close" aria-hidden="true" data-dismiss="modal">×</button>
+    <h3>{{setting "name"}}</h3>
+  </div>
+  <div class="modal-body">
+    <p>{{t "views.resume_modal.body"}}</p>
+  </div>
+  <div class="modal-footer">
+    <button class="btn" aria-hidden="true" data-dismiss="modal">{{t "views.resume_modal.no"}}</button>
+    <button class="btn btn-primary resume-modal-yes">{{t "views.resume_modal.yes"}}</button>
+  </div>
+</div>

--- a/templates/main.hdbs
+++ b/templates/main.hdbs
@@ -29,7 +29,7 @@
   </div>
 {{/if}}
 
-<div class="modal hide fade" id="time-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+<div class="modal hide fade time-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
   <div class="modal-header">
     <button type="button" class="close" aria-hidden="true" data-dismiss="modal">×</button>
     <h3>{{setting "name"}}</h3>
@@ -43,11 +43,11 @@
   </div>
   <div class="modal-footer">
     <button class="btn" aria-hidden="true" data-dismiss="modal">{{t "views.modal.close"}} (<span class="modal-timer">15</span>)</button>
-    <button class="btn btn-primary" id="time-modal-save">{{t "views.modal.save"}}</button>
+    <button class="btn btn-primary time-modal-save">{{t "views.modal.save"}}</button>
   </div>
 </div>
 
-<div class="modal hide fade" id="resume-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+<div class="modal hide fade resume-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
   <div class="modal-header">
     <button type="button" class="close" aria-hidden="true" data-dismiss="modal">×</button>
     <h3>{{setting "name"}}</h3>
@@ -56,7 +56,7 @@
     <p>{{t "views.resume_modal.body"}}</p>
   </div>
   <div class="modal-footer">
-    <button class="btn" id="resume-modal-no">{{t "views.resume_modal.no"}}</button>
-    <button class="btn btn-primary" id="resume-modal-yes">{{t "views.resume_modal.yes"}}</button>
+    <button class="btn resume-modal-no">{{t "views.resume_modal.no"}}</button>
+    <button class="btn btn-primary resume-modal-yes">{{t "views.resume_modal.yes"}}</button>
   </div>
 </div>

--- a/templates/main.hdbs
+++ b/templates/main.hdbs
@@ -43,7 +43,7 @@
   </div>
   <div class="modal-footer">
     <button class="btn" aria-hidden="true" data-dismiss="modal">{{t "views.modal.close"}} (<span class="modal-timer">15</span>)</button>
-    <button class="btn btn-primary time-modal-save">{{t "views.modal.save"}}</button>
+    <button class="btn btn-primary" id="time-modal-save">{{t "views.modal.save"}}</button>
   </div>
 </div>
 
@@ -56,7 +56,7 @@
     <p>{{t "views.resume_modal.body"}}</p>
   </div>
   <div class="modal-footer">
-    <button class="btn resume-modal-no">{{t "views.resume_modal.no"}}</button>
-    <button class="btn btn-primary resume-modal-yes">{{t "views.resume_modal.yes"}}</button>
+    <button class="btn" id="resume-modal-no">{{t "views.resume_modal.no"}}</button>
+    <button class="btn btn-primary" id="resume-modal-yes">{{t "views.resume_modal.yes"}}</button>
   </div>
 </div>

--- a/templates/main.hdbs
+++ b/templates/main.hdbs
@@ -29,7 +29,7 @@
   </div>
 {{/if}}
 
-<div class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+<div class="modal hide fade" id="time-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
   <div class="modal-header">
     <button type="button" class="close" aria-hidden="true" data-dismiss="modal">×</button>
     <h3>{{setting "name"}}</h3>
@@ -43,7 +43,7 @@
   </div>
   <div class="modal-footer">
     <button class="btn" aria-hidden="true" data-dismiss="modal">{{t "views.modal.close"}} (<span class="modal-timer">15</span>)</button>
-    <button class="btn btn-primary modal-save">{{t "views.modal.save"}}</button>
+    <button class="btn btn-primary time-modal-save">{{t "views.modal.save"}}</button>
   </div>
 </div>
 

--- a/translations/en-US.json
+++ b/translations/en-US.json
@@ -76,6 +76,11 @@
       "body": "This is the amount of time you spent on this ticket. Edit the time, if you need to, then click \"Submit time\".",
       "close": "Cancel",
       "save": "Submit time"
+    },
+    "resume_modal": {
+      "body": "Would you like to resume the timer?",
+      "yes": "Yes",
+      "no": "No"
     }
   },
   "errors": {

--- a/translations/en-US.json
+++ b/translations/en-US.json
@@ -31,6 +31,10 @@
         "label": "Reset current time",
         "helpText": "Agents can reset the current time spent on a ticket."
       },
+      "resume_on_changes": {
+        "label": "Resume on changes",
+        "helpText": "The timer resumes automatically when the agent makes changes to any fields."
+      },
       "time_submission": {
         "label": "Edit time submission",
         "helpText": "Agents can review and edit their time before submitting the ticket."

--- a/translations/en-US.json
+++ b/translations/en-US.json
@@ -31,10 +31,6 @@
         "label": "Reset current time",
         "helpText": "Agents can reset the current time spent on a ticket."
       },
-      "resume_on_changes": {
-        "label": "Resume on changes",
-        "helpText": "When changes are made to any fields, a modal will ask if the timer should be resumed."
-      },
       "time_submission": {
         "label": "Edit time submission",
         "helpText": "Agents can review and edit their time before submitting the ticket."
@@ -76,11 +72,6 @@
       "body": "This is the amount of time you spent on this ticket. Edit the time, if you need to, then click \"Submit time\".",
       "close": "Cancel",
       "save": "Submit time"
-    },
-    "resume_modal": {
-      "body": "Would you like to resume the timer?",
-      "yes": "Yes",
-      "no": "No"
     }
   },
   "errors": {

--- a/translations/en-US.json
+++ b/translations/en-US.json
@@ -33,7 +33,7 @@
       },
       "resume_on_changes": {
         "label": "Resume on changes",
-        "helpText": "The timer resumes automatically when the agent makes changes to any fields."
+        "helpText": "When changes are made to any fields, a modal will ask if the timer should be resumed."
       },
       "time_submission": {
         "label": "Edit time submission",

--- a/translations/en.json
+++ b/translations/en.json
@@ -69,6 +69,16 @@
           "value": "The timer pauses when the agent navigates away from the ticket and resumes when the agent is back on the ticket."
         }
       },
+      "resume_on_changes": {
+        "label": {
+          "title": "This is an app setting to display a modal if fields are changed while the timer is paused",
+          "value": "Resume on changes"
+        },
+        "helpText": {
+          "title": "This is the helptext displayed to admins for the app setting to display a modal if fields are changed while the timer is paused",
+          "value": "When changes are made to any fields, a modal will ask if the timer should be resumed."
+        }
+      },
       "reset": {
         "label": {
           "title": "This is a checkbox setting label as well. What this does is let the agent reset the current time he has spent on a specific ticket using a reset button.",
@@ -205,6 +215,20 @@
       "save": {
         "title": "This is the validation button for submitting the time from the modal",
         "value": "Submit time"
+      }
+    },
+    "resume_modal": {
+      "body": {
+        "title": "this is the body of the resume timer modal, this modal asks the agent if they would like to resume the timer if fields change while the timer is paused.",
+        "value": "Would you like to resume the timer?"
+      },
+      "no": {
+        "title": "This is a button on the modal to not resume the timer. Clicking it will dismiss the modal until the timer is manually paused again.",
+        "value": "No"
+      },
+      "yes": {
+        "title": "This is a button to agree to resume the timer.",
+        "value": "Yes"
       }
     }
   },

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -62,6 +62,26 @@ parts:
       title: "this is the explanation helptext of the auto pause checkbox for the admin who is installing the app"
       value: "The timer pauses when the agent navigates away from the ticket and resumes when the agent is back on the ticket."
   - translation:
+      key: "txt.apps.time_tracking.app.parameters.resume_on_changes.label"
+      title: "This is an app setting to display a modal if fields are changed while the timer is paused"
+      value: "Resume on changes"
+  - translation:
+      key: "txt.apps.time_tracking.app.parameters.resume_on_changes.helpText"
+      title: "This is the helptext displayed to admins for the app setting to display a modal if fields are changed while the timer is paused",
+      value: "When changes are made to any fields, a modal will ask if the timer should be resumed."
+  - translation:
+      key: "txt.apps.time_tracking.app.parameters.resume_modal.body": {
+      title: "this is the body of the resume timer modal, this modal asks the agent if they would like to resume the timer if fields change while the timer is paused."
+      value: "Would you like to resume the timer?"
+  - translation:
+      key: "txt.apps.time_tracking.app.parameters.resume_modal.no"
+      title: "This is a button on the modal to not resume the timer. Clicking it will dismiss the modal until the timer is manually paused again.",
+      value: "No"
+  - translation:
+      key: "txt.apps.time_tracking.app.parameters.resume_modal.yes"
+      title: "This is a button to agree to resume the timer."
+      value: "Yes"
+  - translation:
       key: "txt.apps.time_tracking.app.parameters.reset.label"
       title: "This is a checkbox setting label as well. What this does is let the agent reset the current time he has spent on a specific ticket using a reset button."
       value: "Reset current time"

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -64,23 +64,28 @@ parts:
   - translation:
       key: "txt.apps.time_tracking.app.parameters.resume_on_changes.label"
       title: "This is an app setting to display a modal if fields are changed while the timer is paused"
+      screenshot: https://zendesk.app.box.com/files/0/f/12025277114/1/f_160639727838
       value: "Resume on changes"
   - translation:
       key: "txt.apps.time_tracking.app.parameters.resume_on_changes.helpText"
       title: "This is the helptext displayed to admins for the app setting to display a modal if fields are changed while the timer is paused",
+      screenshot: https://zendesk.app.box.com/files/0/f/12025277114/1/f_160639727838
       value: "When changes are made to any fields, a modal will ask if the timer should be resumed."
   - translation:
       key: "txt.apps.time_tracking.app.parameters.resume_modal.body": {
       title: "this is the body of the resume timer modal, this modal asks the agent if they would like to resume the timer if fields change while the timer is paused."
       value: "Would you like to resume the timer?"
+      screenshot: https://zendesk.app.box.com/files/0/f/12025277114/1/f_160639713514
   - translation:
       key: "txt.apps.time_tracking.app.parameters.resume_modal.no"
       title: "This is a button on the modal to not resume the timer. Clicking it will dismiss the modal until the timer is manually paused again.",
       value: "No"
+      screenshot: https://zendesk.app.box.com/files/0/f/12025277114/1/f_160639713514
   - translation:
       key: "txt.apps.time_tracking.app.parameters.resume_modal.yes"
       title: "This is a button to agree to resume the timer."
       value: "Yes"
+      screenshot: https://zendesk.app.box.com/files/0/f/12025277114/1/f_160639713514
   - translation:
       key: "txt.apps.time_tracking.app.parameters.reset.label"
       title: "This is a checkbox setting label as well. What this does is let the agent reset the current time he has spent on a specific ticket using a reset button."


### PR DESCRIPTION
### Description

See #90 and #82 

> If the option is checked, a modal will be displayed asking the agent if they want to resume the timer when any fields change while the timer is paused. If the agent clicks "no" in the modal, the modal will not appear again until the timer is manually resumed and then manually paused. If the agent clicks "yes", it simply resumes the timer.

> I opted against the checkbox I mentioned in the issue (noted above) to "not show this modal again on this ticket", as it seems like not showing it after dismissing with the "no" button seems to be enough. If anyone thinks that I should add that in, let me know and I can add it in.

cc @zendesk/vegemite @jpalmieri

### References
https://zendesk.atlassian.net/browse/TTA-8

### Risks

- [low] new feature