### PR TITLE
[TTA-4] Olaf/follow_up_fix

### DIFF
--- a/app.js
+++ b/app.js
@@ -200,7 +200,7 @@
 
       var audits = response.audits;
 
-      var audits = _.filter(response.audits, function(audit) {
+      var audits = _.filter(audits, function(audit) {
         var isFollowUp = audit.via && audit.via.source && audit.via.source.rel === 'follow_up';
 
         // if not a follow up, it's good.

--- a/app.js
+++ b/app.js
@@ -200,9 +200,7 @@
        * previous ticket.
        */
 
-      var audits = response.audits;
-
-      var audits = _.filter(audits, function(audit) {
+      var audits = _.filter(response.audits, function(audit) {
         var isFollowUp = audit.via && audit.via.source && audit.via.source.rel === 'follow_up';
 
         // if not a follow up, it's good.
@@ -213,7 +211,7 @@
 
         var author = _.find(response.users, function(user) {
           return user.id === audit.author_id;
-        })
+        });
 
         // we can trust if it comes from admin or agent.
         return (author.role === 'admin' || author.role === 'agent');

--- a/app.js
+++ b/app.js
@@ -415,7 +415,7 @@
     },
 
     getTicketForms: function() {
-      if (!this.ticket() || !this.ticket().id()) return;
+      if (!this.ticket().form().id()) { return; }
 
       this.ajaxPaged('ticketForms').done(this.onGetTicketFormsDone.bind(this));
     },

--- a/app.js
+++ b/app.js
@@ -168,6 +168,29 @@
       }
     },
 
+    onGetTicketFormsDone: function(response) {
+      var requiredTicketFieldIds = [
+            timeFieldId,
+            totalTimeFieldId
+          ];
+
+      var forms = _.filter(response.forms, function(form) {
+        return form.active;
+      });
+
+      var valid = _.all(forms, function(form) {
+        return _.intersection(form.ticket_field_ids, requiredTicketFieldIds).length === requiredTicketFieldIds.length;
+      });
+
+      if (!valid) {
+        this.invalid = true;
+        var link = helpers.fmt(this.SETUP_INFO, this.localeForHC());
+        this.switchTo('setup_info', { link: link });
+        this.$('.expand-bar').remove();
+        this.onAppWillDestroy();
+      }
+    },
+
     onGetAuditsDone: function(response) {
       var status = "";
       var timeDiff;
@@ -375,29 +398,6 @@
      * METHODS
      *
      */
-
-    onGetTicketFormsDone: function(response) {
-      var requiredTicketFieldIds = [
-            timeFieldId,
-            totalTimeFieldId
-          ];
-
-      var forms = _.filter(response.forms, function(form) {
-        return form.active;
-      });
-
-      var valid = _.all(forms, function(form) {
-        return _.intersection(form.ticket_field_ids, requiredTicketFieldIds).length === requiredTicketFieldIds.length;
-      });
-
-      if (!valid) {
-        this.invalid = true;
-        var link = helpers.fmt(this.SETUP_INFO, this.localeForHC());
-        this.switchTo('setup_info', { link: link });
-        this.$('.expand-bar').remove();
-        this.onAppWillDestroy();
-      }
-    },
 
     initialize: function() {
       this.getTimelogs();

--- a/app.js
+++ b/app.js
@@ -116,9 +116,9 @@
       console.log('DEBUG: Which is greater than MAX_TIME (s) of: ' +
           this.MAX_TIME);
       console.log('DEBUG: performance object exists: ' +
-          (typeof performance == "object" ? 'yes' : 'no'));
+          (typeof performance === "object" ? 'yes' : 'no'));
       console.log('DEBUG: performance.now function exists: ' +
-          (typeof performance.now == "function" ? 'yes' : 'no'));
+          (typeof performance.now === "function" ? 'yes' : 'no'));
     },
 
     onTicketSave: function() {
@@ -236,7 +236,7 @@
         var timelogs = _.reduce(audits, function(memo, audit) {
 
           var statusEvent = _.find(audit.events, function(event) {
-            return event.field_name == 'status';
+            return event.field_name === 'status';
           }, this);
 
           var auditEvent = _.find(audit.events, function(event) {
@@ -331,7 +331,7 @@
         this.$('.time-modal').modal('hide');
 
       } catch (e) {
-        if (e.message == 'bad_time_format') {
+        if (e.message === 'bad_time_format') {
           services.notify(this.I18n.t('errors.bad_time_format'), 'error');
         } else {
           throw e;

--- a/lib/requests.js
+++ b/lib/requests.js
@@ -10,7 +10,7 @@ function mergePagedData(pages) {
 
     return memo;
   }, {});
-};
+}
 
 module.exports = {
 

--- a/lib/requests.js
+++ b/lib/requests.js
@@ -1,0 +1,55 @@
+function mergePagedData(pages) {
+  return  _.reduce(pages, function(memo, page) {
+    memo.count = page.count;
+
+    _.forEach(page, function(value, property) {
+      if (Array.isArray(value)) {
+        memo[property] = (memo[property] || []).concat(value);
+      }
+    });
+
+    return memo;
+  }, {});
+};
+
+module.exports = {
+
+  ajaxPaged: function() {
+    var request = this.ajax.apply(this, arguments);
+
+    return this.promise(function(res, rej) {
+      var allPages = [];
+
+      request.done(function done(response) {
+        allPages.push(response);
+
+        if (response.next_page) {
+          this.ajax('nextPage', response.next_page).done(done).fail(rej);
+
+        } else {
+          res(mergePagedData(allPages));
+        }
+      }.bind(this)).fail(rej);
+    }.bind(this));
+  },
+
+  requests: {
+    nextPage: function(url) {
+      return {
+        url: url
+      };
+    },
+
+    audits: function() {
+      return {
+        url: helpers.fmt('/api/v2/tickets/%@/audits.json?include=users', this.ticket().id())
+      };
+    },
+
+    ticketForms: function() {
+      return {
+        url: '/api/v2/ticket_forms.json'
+      };
+    }
+  }
+};

--- a/translations/en.json
+++ b/translations/en.json
@@ -71,12 +71,26 @@
       },
       "resume_on_changes": {
         "label": {
-          "title": "This is an app setting to display a modal if fields are changed while the timer is paused",
+          "title": "This is a Time Tracking app setting to display a modal if ticket fields are changed while the timer is paused (resume timer that was paused if there are changes applied to the ticket). See also txt.apps.time_tracking.app.parameters.resume_on_changes.helpText",
           "value": "Resume on changes"
         },
         "helpText": {
           "title": "This is the helptext displayed to admins for the app setting to display a modal if fields are changed while the timer is paused",
           "value": "When changes are made to any fields, a modal will ask if the timer should be resumed."
+        }
+      },
+      "resume_modal": {
+        "body": {
+          "title": "this is the body of the resume timer modal, this modal asks the agent if they would like to resume the timer if fields change while the timer is paused.",
+          "value": "Would you like to resume the timer?"
+        },
+        "no": {
+          "title": "This is a button on the modal to not resume the timer. Clicking it will dismiss the modal until the timer is manually paused again.",
+          "value": "No"
+        },
+        "yes": {
+          "title": "This is a button to agree to resume the timer.",
+          "value": "Yes"
         }
       },
       "reset": {
@@ -215,20 +229,6 @@
       "save": {
         "title": "This is the validation button for submitting the time from the modal",
         "value": "Submit time"
-      }
-    },
-    "resume_modal": {
-      "body": {
-        "title": "this is the body of the resume timer modal, this modal asks the agent if they would like to resume the timer if fields change while the timer is paused.",
-        "value": "Would you like to resume the timer?"
-      },
-      "no": {
-        "title": "This is a button on the modal to not resume the timer. Clicking it will dismiss the modal until the timer is manually paused again.",
-        "value": "No"
-      },
-      "yes": {
-        "title": "This is a button to agree to resume the timer.",
-        "value": "Yes"
       }
     }
   },

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -111,6 +111,14 @@ parts:
       title: "This is the explanation helptext of the simple submission checkbox for the admin who is installing the app: https://www.dropbox.com/s/pw13z83j6qoqktv/Screenshot%202014-08-01%2011.29.46.png"
       value: "Prompt agents to enter a value in minutes before submitting the ticket"
   - translation:
+      key: "txt.apps.time_tracking.app.parameters.debug_prevent_huge_times.label"
+      title: "This is a checkbox setting lable. If the admin checks this box, the agents will not be able to submit 'Time Spent' times exceeding 1209600 seconds, or two weeks."
+      value: "Debug: Block large time spent submissions"
+  - translation:
+      key: "txt.apps.time_tracking.app.parameters.debug_prevent_huge_times.helpText"
+      title: "This is the explanation helptext of the debug (large time spent) checkbox for the admin who is installing the app: https://www.dropbox.com/s/pw13z83j6qoqktv/Screenshot%202014-08-01%2011.29.46.png"
+      value: "Blocks submission of a ticket if an agent is trying to submit a ticket with a Time Spent value (in seconds) greater than 1209600s (two weeks)."
+  - translation:
       key: "txt.apps.time_tracking.statuses.new"
       title: "first letter of status new"
       value: "n"


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description
Changed the follow up mechanism to be smarter.

If the follow up ticket was created by an agent, the follow up audit time is good (because timetracking resets it).
If however the follow up ticket was created by the end user (or system), we have to discard the first audit, because the values get copied from the previous ticket.

### References
* JIRA: https://zendesk.atlassian.net/browse/TTA-4

### Risks
* [medium] Time tracking is wrong.