### PR TITLE
Add correct translation keys for resume_modal

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -10,11 +10,11 @@
     },
     "long_description": {
       "title": "Long Description for App: Time Tracking",
-      "value": "* Automatically track the time spent on each of your Zendesk Support tickets\n* Customize the app to include the exact functionality that your team needs\n* Leverage Insights to create detailed reports with your time tracking data\n\nThe Time Tracking app makes managing your team’s performance and overall support operations easier. Easily identify which customers send in the most complicated tickets, or which issue types take the longest for your team to resolve. Dig down into an agent’s tickets to discover what’s taking up their time and which issues they’re experts on.\n\n### Know exactly how and where your team is spending their time\n\nKeep a running log of which support agents have worked on a ticket and how long each interaction lasted. Automatically log the total time spent the second your agent updates a ticket or let them manually enter their time.\n\n### Easy to setup, customize, and use\n\nThe Time Tracking App doesn’t require any third party set up or login. Simply customize how the Time Tracking App displays and works for your support team, for a seamless fit into your team’s current workflow.\n\n### Report on your time logs and take action\n\nStart reporting right away with easily built custom time tracking reports through Insights. Know exactly what’s draining your support team’s resources and find the best areas for optimization and improvement.\n\nBy enabling this app, You agree to the [Built by Zendesk Terms of Use](https://www.zendesk.com/company/built-by-zendesk-agmt/)."
+      "value": "* Automatically track the time spent on each of your Zendesk Support tickets\n* Customize the app to include the exact functionality that your team needs\n* Leverage Insights to create detailed reports with your time tracking data\n\nThe Time Tracking app makes managing your team’s performance and overall support operations easier. Easily identify which customers send in the most complicated tickets, or which issue types take the longest for your team to resolve. Dig down into an agent’s tickets to discover what’s taking up their time and which issues they’re experts on.\n\n### Know exactly how and where your team is spending their time\n\nKeep a running log of which support agents have worked on a ticket and how long each interaction lasted. Automatically log the total time spent the second your agent updates a ticket or let them manually enter their time.\n\n### Easy to setup, customize, and use\n\nThe Time Tracking App doesn’t require any third party setup or login. Simply customize how the Time Tracking app displays and works for your support team, for a seamless fit into your team’s current workflow.\n\n### Report on your time logs and take action\n\nStart reporting right away with easily built custom time tracking reports through Insights. Know exactly what’s draining your support team’s resources and find the best areas for optimization and improvement.\n\nBy enabling this app, You agree to the [Built by Zendesk Terms of Use](https://www.zendesk.com/company/built-by-zendesk-agmt/)."
     },
     "installation_instructions": {
-      "title": "Installation Instructions for App: Time Tracking",
-      "value": "### Getting started with the Time Tracking app:\n\n1. Sign in to your Zendesk Support account, then click the Admin icon in the sidebar.\n2. Select Apps > Marketplace, then find the Time Tracking app and click the tile.\n3. On the Time Tracking app page, click Install app in the upper-right corner. This app is only available to customers on the Plus and Enterprise plans.\n4. Enter a name for the app, select the configurations you want, then click Install\n5. If you are using Ticket Forms (part of the Productivity Pack add-on), go to Admin > Manage > Ticket Forms and add the ticket fields ‘Total time spent’ and ‘Time spent since last update’ to each of your Ticket Forms."
+      "title": "Installation Instructions for App: Time Tracking. Please keep ‘Total time spent’ & ‘Time spent since last update’ in English.",
+      "value": "### Getting started with the Time Tracking app:\n\n1. Sign in to your Zendesk Support account, then click the Admin icon in the sidebar.\n2. Select **Apps > Marketplace**, then find the Time Tracking app and click the tile.\n3. On the Time Tracking app page, click **Install app** in the upper-right corner. This app is only available to customers on the Professional and Enterprise plans.\n4. Enter a name for the app, select the configurations you want, then click **Install**.\n5. If you are using Ticket Forms (part of the Productivity Pack add-on), go to **Admin > Manage > Ticket Forms** and add the ticket fields ‘Total time spent’ and ‘Time spent since last update’ to each of your Ticket Forms."
     },
     "parameters": {
       "time_field_id": {
@@ -85,20 +85,6 @@
         "helpText": {
           "title": "This is the helptext displayed to admins for the app setting to display a modal if fields are changed while the timer is paused",
           "value": "When changes are made to any fields, a modal will ask if the timer should be resumed."
-        }
-      },
-      "resume_modal": {
-        "body": {
-          "title": "this is the body of the resume timer modal, this modal asks the agent if they would like to resume the timer if fields change while the timer is paused.",
-          "value": "Would you like to resume the timer?"
-        },
-        "no": {
-          "title": "This is a button on the modal to not resume the timer. Clicking it will dismiss the modal until the timer is manually paused again.",
-          "value": "No"
-        },
-        "yes": {
-          "title": "This is a button to agree to resume the timer.",
-          "value": "Yes"
         }
       },
       "reset": {
@@ -195,6 +181,20 @@
           "title": "This is one of the labels of the timelogs column table this column will contain the status of the zendesk ticket at the time of the update",
           "value": "Status"
         }
+      }
+    },
+    "resume_modal": {
+      "body": {
+        "title": "this is the body of the resume timer modal, this modal asks the agent if they would like to resume the timer if fields change while the timer is paused.",
+        "value": "Would you like to resume the timer?"
+      },
+      "no": {
+        "title": "This is a button on the modal to not resume the timer. Clicking it will dismiss the modal until the timer is manually paused again.",
+        "value": "No"
+      },
+      "yes": {
+        "title": "This is a button to agree to resume the timer.",
+        "value": "Yes"
       }
     },
     "timelogs": {

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -55,7 +55,7 @@ By enabling this app, You agree to the [Built by Zendesk Terms of Use](https://w
 
 2. Select **Apps > Marketplace**, then find the Time Tracking app and click the tile.
 
-3. On the Time Tracking app page, click **Install app** in the upper-right corner. This app is only available to customers on the Plus and Enterprise plans.
+3. On the Time Tracking app page, click **Install app** in the upper-right corner. This app is only available to customers on the Professional and Enterprise plans.
 
 4. Enter a name for the app, select the configurations you want, then click **Install**.
 
@@ -123,16 +123,19 @@ By enabling this app, You agree to the [Built by Zendesk Terms of Use](https://w
       title: "this is the body of the resume timer modal, this modal asks the agent if they would like to resume the timer if fields change while the timer is paused."
       value: "Would you like to resume the timer?"
       screenshot: https://zendesk.app.box.com/files/0/f/12025277114/1/f_160639713514
+      obsolete: '2018-01-16'
   - translation:
       key: "txt.apps.time_tracking.app.parameters.resume_modal.no"
       title: "This is a button on the modal to not resume the timer. Clicking it will dismiss the modal until the timer is manually paused again."
       value: "No"
       screenshot: https://zendesk.app.box.com/files/0/f/12025277114/1/f_160639713514
+      obsolete: '2018-01-16'
   - translation:
       key: "txt.apps.time_tracking.app.parameters.resume_modal.yes"
       title: "This is a button to agree to resume the timer."
       value: "Yes"
       screenshot: https://zendesk.app.box.com/files/0/f/12025277114/1/f_160639713514
+      obsolete: '2018-01-16'
   - translation:
       key: "txt.apps.time_tracking.app.parameters.reset.label"
       title: "This is a checkbox setting label as well. What this does is let the agent reset the current time he has spent on a specific ticket using a reset button."
@@ -213,6 +216,18 @@ By enabling this app, You agree to the [Built by Zendesk Terms of Use](https://w
       key: "txt.apps.time_tracking.views.main.timelogs_table.status"
       title: "This is one of the labels of the timelogs column table this column will contain the status of the zendesk ticket at the time of the update"
       value: "Status"
+  - translation:
+      key: "txt.apps.time_tracking.views.resume_modal.body"
+      title: "this is the body of the resume timer modal, this modal asks the agent if they would like to resume the timer if fields change while the timer is paused."
+      value: "Would you like to resume the timer?"
+  - translation:
+      key: "txt.apps.time_tracking.views.resume_modal.no"
+      title: "This is a button on the modal to not resume the timer. Clicking it will dismiss the modal until the timer is manually paused again."
+      value: "No"
+  - translation:
+      key: "txt.apps.time_tracking.views.resume_modal.yes"
+      title: "This is a button to agree to resume the timer."
+      value: "Yes"
   - translation:
       key: "txt.apps.time_tracking.views.timelogs.title"
       title: "This is the label for the timelogs table, the timelogs table are a list of times per agent, kind of the history of the ticket if you will. Following this label will be a table containg time per agent and status of the ticket at the time"


### PR DESCRIPTION
resume_modal strings were defined incorrectly in json file.

Leading to this:
![image](https://user-images.githubusercontent.com/17002719/34928113-7d5979c6-fa0f-11e7-9956-02d948b8fb22.png)

I've just moved the strings around in this PR to fix the issue.
@zendesk/vegemite @zendesk/i18n 